### PR TITLE
add copy, minor edits, and stub out pages for for ticket sales

### DIFF
--- a/fixtures/sitetree.json
+++ b/fixtures/sitetree.json
@@ -555,7 +555,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 8,
-        "sort_order": 36,
+        "sort_order": 15,
         "access_permissions": []
     }
 },
@@ -603,7 +603,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 8,
-        "sort_order": 15,
+        "sort_order": 36,
         "access_permissions": []
     }
 }

--- a/fixtures/sitetree.json
+++ b/fixtures/sitetree.json
@@ -27,7 +27,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 2,
+        "sort_order": 7,
         "access_permissions": []
     }
 },
@@ -51,7 +51,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 8,
+        "sort_order": 24,
         "access_permissions": []
     }
 },
@@ -83,9 +83,9 @@
     "model": "sitetree.treeitem",
     "pk": 8,
     "fields": {
-        "title": "Safety",
+        "title": "Attend",
         "hint": "",
-        "url": "/code-of-conduct",
+        "url": "/attend",
         "urlaspattern": false,
         "tree": 1,
         "hidden": false,
@@ -99,7 +99,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 9,
+        "sort_order": 8,
         "access_permissions": []
     }
 },
@@ -123,7 +123,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 24,
+        "sort_order": 25,
         "access_permissions": []
     }
 },
@@ -171,7 +171,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 1,
-        "sort_order": 12,
+        "sort_order": 13,
         "access_permissions": []
     }
 },
@@ -195,55 +195,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 1,
-        "sort_order": 13,
-        "access_permissions": []
-    }
-},
-{
-    "model": "sitetree.treeitem",
-    "pk": 14,
-    "fields": {
-        "title": "Reporting an Incident",
-        "hint": "",
-        "url": "/code-of-conduct/harassment-incidents",
-        "urlaspattern": false,
-        "tree": 1,
-        "hidden": false,
-        "alias": null,
-        "description": "",
-        "inmenu": true,
-        "inbreadcrumbs": true,
-        "insitetree": true,
-        "access_loggedin": false,
-        "access_guest": false,
-        "access_restricted": false,
-        "access_perm_type": 1,
-        "parent": 8,
-        "sort_order": 15,
-        "access_permissions": []
-    }
-},
-{
-    "model": "sitetree.treeitem",
-    "pk": 15,
-    "fields": {
-        "title": "Staff Procedures",
-        "hint": "",
-        "url": "/code-of-conduct/harassment-staff-procedures",
-        "urlaspattern": false,
-        "tree": 1,
-        "hidden": false,
-        "alias": null,
-        "description": "",
-        "inmenu": true,
-        "inbreadcrumbs": true,
-        "insitetree": true,
-        "access_loggedin": false,
-        "access_guest": false,
-        "access_restricted": false,
-        "access_perm_type": 1,
-        "parent": 8,
-        "sort_order": 17,
+        "sort_order": 33,
         "access_permissions": []
     }
 },
@@ -267,7 +219,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": 8,
-        "sort_order": 14,
+        "sort_order": 37,
         "access_permissions": []
     }
 },
@@ -328,7 +280,7 @@
         "url": "/program",
         "urlaspattern": false,
         "tree": 1,
-        "hidden": true,
+        "hidden": false,
         "alias": null,
         "description": "",
         "inmenu": true,
@@ -339,7 +291,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 7,
+        "sort_order": 9,
         "access_permissions": []
     }
 },
@@ -349,8 +301,8 @@
     "fields": {
         "title": "Log In",
         "hint": "",
-        "url": "nbpy_login",
-        "urlaspattern": true,
+        "url": "/account/login/",
+        "urlaspattern": false,
         "tree": 1,
         "hidden": false,
         "alias": null,
@@ -363,7 +315,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 26,
+        "sort_order": 29,
         "access_permissions": []
     }
 },
@@ -387,7 +339,7 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 29,
+        "sort_order": 30,
         "access_permissions": []
     }
 },
@@ -459,7 +411,199 @@
         "access_restricted": false,
         "access_perm_type": 1,
         "parent": null,
-        "sort_order": 25,
+        "sort_order": 26,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 30,
+    "fields": {
+        "title": "North Bay Python",
+        "hint": "",
+        "url": "/",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": true,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": null,
+        "sort_order": 2,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 31,
+    "fields": {
+        "title": "Make a Donation",
+        "hint": "",
+        "url": "/donate",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 3,
+        "sort_order": 31,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 32,
+    "fields": {
+        "title": "Events",
+        "hint": "",
+        "url": "/program/events",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 24,
+        "sort_order": 32,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 33,
+    "fields": {
+        "title": "Petaluma",
+        "hint": "",
+        "url": "/about/petaluma",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 1,
+        "sort_order": 12,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 34,
+    "fields": {
+        "title": "Buy a Ticket",
+        "hint": "",
+        "url": "/attend",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 8,
+        "sort_order": 14,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 35,
+    "fields": {
+        "title": "How to Pitch Your Manager",
+        "hint": "",
+        "url": "/attend/business-cases",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 8,
+        "sort_order": 36,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 36,
+    "fields": {
+        "title": "How to Get Here",
+        "hint": "",
+        "url": "/attend/travel",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 8,
+        "sort_order": 35,
+        "access_permissions": []
+    }
+},
+{
+    "model": "sitetree.treeitem",
+    "pk": 37,
+    "fields": {
+        "title": "Where to Stay",
+        "hint": "",
+        "url": "/attend/hotels",
+        "urlaspattern": false,
+        "tree": 1,
+        "hidden": false,
+        "alias": null,
+        "description": "",
+        "inmenu": true,
+        "inbreadcrumbs": true,
+        "insitetree": true,
+        "access_loggedin": false,
+        "access_guest": false,
+        "access_restricted": false,
+        "access_perm_type": 1,
+        "parent": 8,
+        "sort_order": 15,
         "access_permissions": []
     }
 }

--- a/pinaxcon/templates/_footer.html
+++ b/pinaxcon/templates/_footer.html
@@ -14,8 +14,9 @@
       <a href="https://facebook.com/northbaypython">Facebook</a>
       | <a href="https://twitter.com/northbaypython">Twitter</a>
       | <a href="/code-of-conduct">Code of Conduct</a>
+      | <a href="/terms">Terms and Conditions</a>
       | <a href="/about/colophon">Colophon</a>
-      | <a href="/about/donate">Donate</a>
+      | <a href="/donate">Donate</a>
     </p>
 
     <p>This site is <a href="https://github.com/northbaypython/website">free and open source software</a>, powered by <a href="https://github.com/chrisjrn/symposion/">Symposion</a> and <a href="https://github.com/chrisjrn/registrasion/">Registrasion</a>.</p>

--- a/pinaxcon/templates/static_pages/about/colophon.html
+++ b/pinaxcon/templates/static_pages/about/colophon.html
@@ -36,7 +36,7 @@
 <h2>Terms and Conditions</h2>
 
 <p>
-  Our Photography and Audio Video Recording policy is adapted from the <a href="https://evergreen-ils.org/conference/photography-policy/">Evergreen policy</a>, itself adapted from the <a href="https://adacamp.org/adacamp-toolkit/policies/#photo">AdaCamp policy</a> under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Share Alike 4.0 International</a> license.</p>
+  Our <a href="/terms-and-conditions">Terms and Conditions</a> were forked from the <a href="https://github.com/linuxaustralia/constitution_and_policies/blob/master/terms_and_conditions.md">Linux Australia Event Terms and Conditions</a> under the <a href="https://creativecommons.org/licenses/by-sa/3.0/au/">Creative Commons Attribution Share Alike 3.0 Australia</a> license. Our Photography and Audio Video Recording policy is adapted from the <a href="https://evergreen-ils.org/conference/photography-policy/">Evergreen policy</a>, itself adapted from the <a href="https://adacamp.org/adacamp-toolkit/policies/#photo">AdaCamp policy</a> under a <a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution Share Alike 4.0 International</a> license.</p>
 
 <h2>Web Application</h2>
 

--- a/pinaxcon/templates/static_pages/about/north_bay_python.html
+++ b/pinaxcon/templates/static_pages/about/north_bay_python.html
@@ -18,7 +18,7 @@
 
 <p>We're a nonprofit conference for professionals, enthusiasts and students alike. We're focused on inclusion, accessibility, diversity, and affordability. Most importantly, we're planning a great lineup of talks from all over the Python ecosystem, with plenty of time to meet new people and develop new ideas.</p>
 
-<p>Our venue, the Mystic Theatre in Downtown Petaluma, is a beautiful example of an early 1900s Vaudeville theatre. You can find over 50 different food and drink options a short walk away, and the nearest hotel is only a block away.</p>
+<p>Our venue, the Mystic Theatre in Downtown Petaluma, is a beautiful example of an early 1900s Vaudeville theatre. You can find over 50 different food and drink options within a short walk, and the nearest hotel is only a block away.</p>
 
 <h2>The Conference</h2>
 
@@ -36,8 +36,8 @@
 
 <h2>Travel and Accommodation</h2>
 
-<p>The Golden Gate Bridge is known to San Franciscans as being approximately 8,000 miles long behind the fog, so few ever cross up into the North Bay. If you actually try driving here, it's not very difficult. There are many ways to get to Petaluma and, when you get here, you'll have a nice place to stay that fits your budget.</p>
+<p>The Golden Gate Bridge is seen by San Franciscans as being approximately 8,000 miles long and shrouded in fog, so few ever cross up into the North Bay. Happily, the drive north is easy and it can be swift. There are many ways to get to Petaluma, we've covered driving, public transit, and flights on the <a href="/attend/travel">How to Get Here</a> page.</p>
 
-<p>You can find details about traveling to Petaluma on our <a href="/attend/travel">How to Get Here</a> page and information on hotels and lodging options on our <a href="/attend/hotels">Where to Stay</a> page.</p>
+<p>When you get here, you're sure to find a nice place to stay that fits your budget. You can find a range of options, and some special discounts, available on the <a href="/attend/hotels">Where to Stay</a> page.</p>
 
 {% endblock %}

--- a/pinaxcon/templates/static_pages/about/north_bay_python.html
+++ b/pinaxcon/templates/static_pages/about/north_bay_python.html
@@ -20,7 +20,6 @@
 
 <p>Our venue, the Mystic Theatre in Downtown Petaluma, is a beautiful example of an early 1900s Vaudeville theatre. You can find over 50 different food and drink options a short walk away, and the nearest hotel is only a block away.</p>
 
-
 <h2>The Conference</h2>
 
 <p>North Bay Python is a single-track conference with a carefully curated set of talks representing the diverse Python community and their different areas of interest.</p>
@@ -29,33 +28,16 @@
 
 <p>Our goal is to keep prices as low as possible. That means we won't be catering lunch. Instead, you can look forward to extra-long lunch breaks you can use to explore all of the great food options around the venue.</p>
 
-
 <h2>Petaluma, California</h2>
 
-<p>North Bay Python's home is Petaluma, a delightfully quaint dairy town, nestled on a river at the southern edge of California's Wine Country. We've got beautiful scenery right on our doorstep, and we're less than an hour's drive from San Francisco over the Golden Gate Bridge.</p>
+<p>North Bay Python's home is <a href="/about/petaluma">Petaluma</a>, a delightfully quaint dairy town, nestled on a river at the southern edge of California's Wine Country. We've got beautiful scenery right on our doorstep, and we're less than an hour's drive from San Francisco over the Golden Gate Bridge. We've got a whole page dedicated to <a href="/about/petaluma">Petaluma</a> if you want to learn more about it.</p>
 
-<p>The Mystic is not the only local example of early 1900s architecture, either: Downtown is full of great examples of Victorian-era buildings that survived the 1906 earthquake. Just down the road, you'll find the center of the maker movement and a thriving craft brewery scene.</p>
+<p>Our venue, The Mystic, is not the only local example of early 1900s architecture, either: Downtown is full of great examples of Victorian-era buildings that survived the 1906 earthquake. Just down the road, you'll find the center of the maker movement and a thriving craft brewery scene.</p>
 
+<h2>Travel and Accommodation</h2>
 
-<h3>Getting Here</h3>
+<p>The Golden Gate Bridge is known to San Franciscans as being approximately 8,000 miles long behind the fog, so few ever cross up into the North Bay. If you actually try driving here, it's not very difficult. There are many ways to get to Petaluma and, when you get here, you'll have a nice place to stay that fits your budget.</p>
 
-<h4>By Car</h4>
-
-<p>If you're driving up, Downtown Petaluma is at exit 472 on Highway 101, 35 miles north of the Golden Gate Bridge. All parking is free in Petaluma, including in the undercover garages at Keller St and Theatre Square. Both garages are in short walking distance of the Mystic.</p>
-
-<h4>By Bus</h4>
-
-<p>Public transit to Petaluma is not great. You can take the 101 bus operated by Golden Gate Transit from downtown San Francisco, or south from Santa Rosa. Depending on sponsorship, we hope to run a free shuttle with BART and Caltrain connections for people from further out of town.</p>
-
-<h4>By Plane</h4>
-
-<p>If you're coming from out of the area, you may want to consider Sonoma County Airport (STS). STS is 30 minutes out of Petaluma, and has nonstop flights to most major west coast cities. If you can't make it to STS, you can also try San Francisco (SFO) or Oakland (OAK) international airports.</p>
-
-<p>If you happen to have an aircraft of your own, Petaluma Municipal Airport is 3 miles down the road.</p>
-
-
-<h3>Staying Here</h3>
-
-<p>Petaluma also has hotels! We're arranging deals with some of the best local hotels in the area &ndash; the closest is just one block away. We'll share details with you when conference tickets go on sale.</p>
+<p>You can find details about traveling to Petaluma on our <a href="/attend/travel">How to Get Here</a> page and information on hotels and lodging options on our <a href="/attend/hotels">Where to Stay</a> page.</p>
 
 {% endblock %}

--- a/pinaxcon/templates/static_pages/about/petaluma.html
+++ b/pinaxcon/templates/static_pages/about/petaluma.html
@@ -15,6 +15,6 @@
 
 {% block content %}
 
-Content
+reuse existing content and point to How to Get Here, Where to Stay, and the Wiki
 
 {% endblock %}

--- a/pinaxcon/templates/static_pages/about/petaluma.html
+++ b/pinaxcon/templates/static_pages/about/petaluma.html
@@ -1,0 +1,20 @@
+{% extends "page_with_title_and_lede.html" %}
+
+{% load i18n %}
+
+{% block head_title %}Petaluma{% endblock %}
+
+{% block heading %}Petaluma{% endblock %}
+
+{% block body_class %}about{% endblock %}
+
+{% block lede %}
+  Lede
+{% endblock %}
+
+
+{% block content %}
+
+Content
+
+{% endblock %}

--- a/pinaxcon/templates/static_pages/attend/attend.html
+++ b/pinaxcon/templates/static_pages/attend/attend.html
@@ -1,0 +1,20 @@
+{% extends "page_with_title_and_lede.html" %}
+
+{% load i18n %}
+
+{% block head_title %}Attend{% endblock %}
+
+{% block heading %}Attend{% endblock %}
+
+{% block body_class %}attend{% endblock %}
+
+{% block lede %}
+  Lede
+{% endblock %}
+
+
+{% block content %}
+
+Content
+
+{% endblock %}

--- a/pinaxcon/templates/static_pages/attend/business-case.html
+++ b/pinaxcon/templates/static_pages/attend/business-case.html
@@ -9,26 +9,51 @@
 {% block body_class %}attend{% endblock %}
 
 {% block lede %}
-  Lede
+So you want to attend North Bay Python, but you're not quite sure your manager will sign off on the expenses? Read below for some suggestions on how to make your case!
 {% endblock %}
 
 
 {% block content %}
 
-<h3>Making a Business Case for Attending, or: How to Pitch Your Manager</h3>
+<h3>Key Information</h3>
+<p>
+<ul>
+    <li>Dates: Saturday, December 2nd and Sunday, December 3rd, 2017</li>
+    <li>Venue: Mystic Theatre, Petaluma, California, USA</li>
+    <li>Tickets: $200</li>
+</ul>
+</p>
 
-<h4>Why Go to Conferences at All?</h4>
-<p>Conferences are a fantastic way to broaden your horizons as a Python user and maker of software. You'll hear about new and exciting ways to use Python, best practices for building, testing, and deploying your software and for working together as a team and community of Pythonistas, and more. And that's just from the scheduled talks — during breaks and in the evening, you'll be having coffee or lunch with fellow attendees and discussing whatever strikes your fancy.</p>
+<h3>How to Convince Your Boss</h3>
 
-<h4>Why Attend North Bay Python?</h4>
+<p>
+This comes down to building a <em>business case</em> for your attendance. Start by explaining what the conference is, why you want to go, and why your employer will benefit (we've helpfully included some of the great reasons you might use and some sample prose you're welcome to copy into your email, below).</p>
 
-<p>If you're in the Bay Area already, North Bay Python is easy to travel to and inexpensive, while maintaining the same commitment to well-curated, world-class content. Many of our speakers have presented at larger Python conferences and other events around the world.</p>
+<p>Explain to your boss what you'll bring back for the rest of the team (ideas, not imbibables): offer to give a summary presentation at lunch, or post a write-up to the company wiki, upon your return. We have some fantastic content in store, and you'll have no trouble finding things to teach your teammates when you get back. Sessions will be recorded and posted to YouTube, so you'll have ready-to-share links for those who want additional detail. You could also share the names, Twitter handles, or business cards from the people you'll meet — some of them might even be interested in working with you!</p>
 
-<p>Our community is also a great place to connect with Python users who might be seeking employment, or vendors that might just solve a problem your team has been wrestling with.</p>
+<h3>Sample Language</h3>
+<p>
+North Bay Python is a new, non-profit conference by and for the Python community.
+</p>
 
-<h4>What Does the Company Get?</h4>
+<p>
+The conference features over 20 sessions from experienced presenters hailing from across the US and internationally, speaking on a wide mix of topics. Sessions will include updates from leading Python community members on the state of major projects, technical explorations of how Python and Python-based systems work in practice, and thought-provoking explorations and lessons on how best to communicate as a team, foster diversity and inclusivity, and effectively engage within and beyond our teams and communities as developers.
+</p>
 
-<p>Your employer could <a href="/sponsors">sponsor North Bay Python</a><!-- oh god how do I link properly again? -->, putting their brand front and center in front of approximately 400 attendees. Even without a sponsorship, however, a Professional registration gets your employer's name on your badge and demonstrates their commitment to supporting the non-profit events and communities that produce the open-source Python software we all use.</p>
+<p>Full details on the program will be released soon.</p>
 
-<p>Offer to take notes and summarize the conference for your co-workers — a post-conference report is a good way to show concrete knowledge you acquired and share it with others. Managers love things like this.</p>
+<p>
+Approximately 400 attendees from a diverse mix of backgrounds will be in Petaluma for the weekend, providing a rich opportunity for networking. Expect to meet key members of your favorite open-source Python projects, fellow developers with novel perspectives on common problems, and maybe even some job-seekers to help bolster your organization's ranks.
+</p>
+
+<p>
+Organizations funding attendees of North Bay Python can acquire competitive advantage by:
+<ul>
+    <li>Staying abreast of the latest libraries, services, and best practices in the Python ecosystem</li>
+    <li>Learning techniques for architecting, authoring, deploying, and maintaining software</li>
+    <li>Improving technical and organizational communication skills</li>
+    <li>Networking with fellow Python users to establish potential future working relationships</li>
+    <li>Returning to work refreshed and excited by all of the novel ways Python is being used across industries</li>
+</ul>
+</p>
 {% endblock %}

--- a/pinaxcon/templates/static_pages/attend/business-case.html
+++ b/pinaxcon/templates/static_pages/attend/business-case.html
@@ -1,0 +1,20 @@
+{% extends "page_with_title_and_lede.html" %}
+
+{% load i18n %}
+
+{% block head_title %}How to Pitch Your Manager{% endblock %}
+
+{% block heading %}How to Pitch Your Manager{% endblock %}
+
+{% block body_class %}attend{% endblock %}
+
+{% block lede %}
+  Lede
+{% endblock %}
+
+
+{% block content %}
+
+Content
+
+{% endblock %}

--- a/pinaxcon/templates/static_pages/attend/business-case.html
+++ b/pinaxcon/templates/static_pages/attend/business-case.html
@@ -15,6 +15,20 @@
 
 {% block content %}
 
-Content
+<h3>Making a Business Case for Attending, or: How to Pitch Your Manager</h3>
 
+<h4>Why Go to Conferences at All?</h4>
+<p>Conferences are a fantastic way to broaden your horizons as a Python user and maker of software. You'll hear about new and exciting ways to use Python, best practices for building, testing, and deploying your software and for working together as a team and community of Pythonistas, and more. And that's just from the scheduled talks — during breaks and in the evening, you'll be having coffee or lunch with fellow attendees and discussing whatever strikes your fancy.</p>
+
+<h4>Why Attend North Bay Python?</h4>
+
+<p>If you're in the Bay Area already, North Bay Python is easy to travel to and inexpensive, while maintaining the same commitment to well-curated, world-class content. Many of our speakers have presented at larger Python conferences and other events around the world.</p>
+
+<p>Our community is also a great place to connect with Python users who might be seeking employment, or vendors that might just solve a problem your team has been wrestling with.</p>
+
+<h4>What Does the Company Get?</h4>
+
+<p>Your employer could <a href="/sponsors">sponsor North Bay Python</a><!-- oh god how do I link properly again? -->, putting their brand front and center in front of approximately 400 attendees. Even without a sponsorship, however, a Professional registration gets your employer's name on your badge and demonstrates their commitment to supporting the non-profit events and communities that produce the open-source Python software we all use.</p>
+
+<p>Offer to take notes and summarize the conference for your co-workers — a post-conference report is a good way to show concrete knowledge you acquired and share it with others. Managers love things like this.</p>
 {% endblock %}

--- a/pinaxcon/templates/static_pages/attend/business-case.html
+++ b/pinaxcon/templates/static_pages/attend/business-case.html
@@ -33,7 +33,7 @@ This comes down to building a <em>business case</em> for your attendance. Start 
 
 <h3>Sample Language</h3>
 <p>
-North Bay Python is a new, non-profit conference by and for the Python community.
+North Bay Python is a new, nonprofit conference by and for the Python community.
 </p>
 
 <p>
@@ -43,7 +43,7 @@ The conference features over 20 sessions from experienced presenters hailing fro
 <p>Full details on the program will be released soon.</p>
 
 <p>
-Approximately 400 attendees from a diverse mix of backgrounds will be in Petaluma for the weekend, providing a rich opportunity for networking. Expect to meet key members of your favorite open-source Python projects, fellow developers with novel perspectives on common problems, and maybe even some job-seekers to help bolster your organization's ranks.
+Approximately 400 attendees from a diverse mix of backgrounds will be in Petaluma for the weekend, providing a rich opportunity for networking. Expect to meet key members of your favorite open source Python projects, fellow developers with novel perspectives on common problems, and maybe even some job-seekers to help bolster your organization's ranks.
 </p>
 
 <p>

--- a/pinaxcon/templates/static_pages/attend/hotels.html
+++ b/pinaxcon/templates/static_pages/attend/hotels.html
@@ -1,0 +1,20 @@
+{% extends "page_with_title_and_lede.html" %}
+
+{% load i18n %}
+
+{% block head_title %}Where to Stay{% endblock %}
+
+{% block heading %}Where to Stay{% endblock %}
+
+{% block body_class %}attend{% endblock %}
+
+{% block lede %}
+  Lede
+{% endblock %}
+
+
+{% block content %}
+
+Content
+
+{% endblock %}

--- a/pinaxcon/templates/static_pages/attend/hotels.html
+++ b/pinaxcon/templates/static_pages/attend/hotels.html
@@ -17,4 +17,46 @@
 
 Content
 
+<!--
+
+<h3>Staying Here</h3>
+
+<p>Petaluma also has hotels! We're arranging deals with some of the best local hotels in the area &ndash; the closest is just one block away. We'll share details with you when conference tickets go on sale.</p>
+
+# Confirmed and co-operating:
+
+- Hotel Petaluma: Two blocks away. Exclusive rate, starts at $117+tax.
+- Sheraton: 1.7mi away, on the river. Exclusive rate, starts at $129+tax
+- Quality Inn: 3.7mi away, on the freeway. Discount rate (15% off the
+public rate), currently starts at $81+tax
+
+
+
+# In progress + likely:
+
+- America's Best Value Inn: 3.7mi away, on the freeway. Working on an
+exclusive rate, with some rooms held (they want a credit card to hold
+rooms). Currently starts at $70+tax.
+
+
+# In progress + questionable
+
+- Best Western: 1.5mi away, on the freeway. They offer 10% off for
+people who sign up for their mailing list, or AAA members. Currently
+starts at $75+tax.
+
+
+# Not yet contacted:
+
+- Motel 6: 3.7mi away, near the freeway. Opposite Lagunitas. Currently
+starts at $70+tax.
+
+
+Won't contact, but will advertise:
+
+KOA camping+cabins: 3.7mi away, near the freeway. Have 3-bed cabins
+with bathrooms for $99, and 6-bed cabins with bathrooms for $149.
+
+-->
+
 {% endblock %}

--- a/pinaxcon/templates/static_pages/attend/travel.html
+++ b/pinaxcon/templates/static_pages/attend/travel.html
@@ -15,6 +15,20 @@
 
 {% block content %}
 
-Content
+<h3>Getting Here</h3>
+
+<h4>By Car</h4>
+
+<p>If you're driving up, Downtown Petaluma is at exit 472A on Highway 101, 35 miles north of the Golden Gate Bridge. All parking is free in Petaluma, including in the undercover garages at Keller St and Theatre Square. Both garages are in short walking distance of the Mystic.</p>
+
+<h4>By Bus</h4>
+
+<p>Public transit to Petaluma is not great. You can take the 101 bus operated by Golden Gate Transit from downtown San Francisco, or south from Santa Rosa. Depending on sponsorship, we hope to run a free shuttle with BART and Caltrain connections for people from further out of town.</p>
+
+<h4>By Plane</h4>
+
+<p>If you're coming from out of the area, you may want to consider Sonoma County Airport (STS). STS is 30 minutes out of Petaluma, and has nonstop flights to most major west coast cities. If you can't make it to STS, you can also try San Francisco (SFO) or Oakland (OAK) international airports.</p>
+
+<p>If you happen to have an aircraft of your own, Petaluma Municipal Airport is 3 miles down the road.</p>
 
 {% endblock %}

--- a/pinaxcon/templates/static_pages/attend/travel.html
+++ b/pinaxcon/templates/static_pages/attend/travel.html
@@ -1,0 +1,20 @@
+{% extends "page_with_title_and_lede.html" %}
+
+{% load i18n %}
+
+{% block head_title %}How to Get Here{% endblock %}
+
+{% block heading %}How to Get Here{% endblock %}
+
+{% block body_class %}attend{% endblock %}
+
+{% block lede %}
+  Lede
+{% endblock %}
+
+
+{% block content %}
+
+Content
+
+{% endblock %}

--- a/pinaxcon/templates/static_pages/news.html
+++ b/pinaxcon/templates/static_pages/news.html
@@ -10,6 +10,23 @@
 
 {% block content %}
 
+<a name="3"></a>
+<h2>Tickets now on sale for North Bay Python 2017</h2>
+
+<p><span class="date">Tuesday, October 3, 2017</span>&mdash;We are excited to announce that <a href="https://2017.northbaypython.org/tickets">tickets are now on sale</a> for North Bay Python 2017! Tickets are available at a discounted "early bird" rate for the first 100 attendees, or until X, whichever comes first.</p>
+
+<p>You can buy a ticket for as low as $25 if you're a student who catches the early bird rate and tickets for corporate employees start at $180. Because we are a nonprofit conference, we also offer individual sponsorships via tickets starting at $450.</p>
+
+<p>Can't afford a ticket? Please email <a href="mailto:spam@northbaypython.org">spam@northbaypython.org</a>. We'll enthusiastically waive ticket fees for anyone who needs it.</p>
+
+<p>A limited edition North Bay Python 2017 t-shirt is included with all but the lowest level tickets sold before Wednesday, November 8. You can add t-shirts to any order, as well.</p>
+
+<p>Wondering how you'll get to North Bay Python or where you'll stay? We've gathered all the information you need and are working with local hotels to make sure you have a nice place to stay that fits your budget. Details on our <a href="https://2017.northbaypython.org/about/petaluma">About Petaluma</a> page.</p>
+
+<p>Need to get approval from your manager to attend North Bay Python 2017? We've outlined the <a href="https://2017.northbaypython.org/attend/business-case">business case</a> to make it clear that North Bay Python is a wise investment.</p>
+
+<p>Our venue can only hold 450 people. <a href="https://2017.northbaypython.org/tickets">Register today</a> so you don't miss out!</p>
+
 <a name="2"></a>
 <h2>Reflecting the Bay in the North Bay Python 2017 speaker lineup</h2>
 
@@ -43,25 +60,25 @@
 <a name="1"></a>
 <h2>Now accepting talk proposals for North Bay Python 2017</h2>
 
-<p><span class="date">Monday, August 21, 2017</span>&mdash;The North Bay Python team is excited to announce that the <a href="/program/call-for-proposals" title="North Bay Python Call for Proposals">call for proposals</a> (CFP) is now open! We are seeking speakers of all experience levels to contribute to our inaugural conference. The CFP will close on September 29, 2017.</p>
+<p><span class="date">Monday, August 21, 2017</span>&mdash;The North Bay Python team is excited to announce that the <a href="https://2017.northbaypython.org/program/call-for-proposals">call for proposals</a> (CFP) is now open! We are seeking speakers of all experience levels to contribute to our inaugural conference. The CFP will close on September 29, 2017.</p>
 
 <p>North Bay Python is a single-track event featuring two days of presentations by members of the community. The vast majority of the conference program will come from people who propose talks in our CFP process. Whether you use Python professionally, as a hobbyist, or are just excited about Python or programming and open source, we'd love to hear from you.</p>
 
 <p>Our program committee, which is responsible for reviewing proposals, is interested in building a program that reflects the diversity of people who are using Python. Never given a presentation before but excited to share? We're here to help you craft a proposal and can refer you to quality resources for making your first conference talk. Not sure what to talk about, but interested in trying? We've got ideas for presentations we'd love to see and we're happy to share them with you!</p>
 
-<p>In order to ensure a balanced program, we are proactively doing outreach to new and experienced speakers alike. We are also including a blind review phase in our <a href="/program/selection-process" title="North Bay Python proposal selection process">selection process</a> in order to combat bias. Our goal is to have no less than 33% of our speakers be not-men, ideally 50%, and to reflect the racial diversity of United States and Bay Area demographics.</p>
+<p>In order to ensure a balanced program, we are proactively doing outreach to new and experienced speakers alike. We are also including a blind review phase in our <a href="https://2017.northbaypython.org/program/selection-process">selection process</a> in order to combat bias. Our goal is to have no less than 33% of our speakers be not-men, ideally 50%, and to reflect the racial diversity of United States and Bay Area demographics.</p>
 
-<p>Feel free to reach out with any questions, comments, or ideas you have. You can find us on <a href="https://twitter.com/northbaypython" title="North Bay Python on Twitter">Twitter</a>, <a href="https://facebook.com/northbaypython" title="North Bay Python on Facebook">Facebook</a>, and <a href="https://webchat.freenode.net/?channels=%23nbpy" title="IRC Web Client for #nbpy Channel on Freenode">IRC</a>, or you can <a href="mailto:program@northbaypython.org" title="program@northbaypython.org">email us</a>. Please, get started today! The <a href="/program/call-for-proposals" title="North Bay Python Call for Proposals">call for proposals</a> closes on September 29, 2017.</p>
+<p>Feel free to reach out with any questions, comments, or ideas you have. You can find us on <a href="https://twitter.com/northbaypython">Twitter</a>, <a href="https://facebook.com/northbaypython">Facebook</a>, and <a href="https://webchat.freenode.net/?channels=%23nbpy">IRC</a>, or you can <a href="mailto:program@northbaypython.org">email us</a>. Please, get started today! The <a href="https://2017.northbaypython.org/program/call-for-proposals">call for proposals</a> closes on September 29, 2017.</p>
 
 <a name="0"></a>
 <h2>North Bay Python joins Software Freedom Conservancy</h2>
 
-<p><span class="date">Wednesday, August 16, 2017</span>&mdash;We are proud to announce that North Bay Python is now a member project of <a href="https://sfconservancy.org" title="Software Freedom Conservancy">Software Freedom Conservancy</a>, a 501(c)(3) charity dedicated to ethical technology and the development and promotion free and open source software. Conservancy will act as our fiscal sponsor, allowing our team to operate without managing our own corporate structure and administrative services.</p>
+<p><span class="date">Wednesday, August 16, 2017</span>&mdash;We are proud to announce that North Bay Python is now a member project of <a href="https://sfconservancy.org">Software Freedom Conservancy</a>, a 501(c)(3) charity dedicated to ethical technology and the development and promotion free and open source software. Conservancy will act as our fiscal sponsor, allowing our team to operate without managing our own corporate structure and administrative services.</p>
 
-<p>Conservancy is home to many popular <a href="https://sfconservancy.org/projects/current/" title="Current Member Projects of the Software Freedom Conservancy">free and open source software projects</a>, like <a href="http://www.seleniumhq.org/" title="Selenium">Selenium</a>, <a href="https://pypy.org/" title="PyPy">PyPy</a>, <a href="https://www.phpmyadmin.net/" title="phpMyAdmin">phpMyAdmin</a>, <a href="https://twistedmatrix.com/trac/" title="Twisted">Twisted</a>, and <a href="https://www.gnome.org/outreachy/" title="Outreachy">Outreachy</a>, some of which run their own events. North Bay Python has the distinct honor of being the first member project that is exclusively focused on organizing community events.</p>
+<p>Conservancy is home to many popular <a href="https://sfconservancy.org/projects/current/">free and open source software projects</a>, like <a href="http://www.seleniumhq.org/">Selenium</a>, <a href="https://pypy.org/">PyPy</a>, <a href="https://www.phpmyadmin.net/">phpMyAdmin</a>, <a href="https://twistedmatrix.com/trac/">Twisted</a>, and <a href="https://www.gnome.org/outreachy/">Outreachy</a>, some of which run their own events. North Bay Python has the distinct honor of being the first member project that is exclusively focused on organizing community events.</p>
 
-<p>We couldn't be more excited. We're celebrating by donating five free tickets to Outreachy participants and will be promoting member projects relevant to the Python community at the conference. Interested Outreachy alums (past or present) should <a href="mailto:outreach@northbaypython.org" title="outreach@northbaypython.org">contact us</a>. We'll also have discounted tickets available for active financial supporters of Software Freedom Conservancy.</p>
+<p>We couldn't be more excited. We're celebrating by donating five free tickets to Outreachy participants and will be promoting member projects relevant to the Python community at the conference. Interested Outreachy alums (past or present) should <a href="mailto:outreach@northbaypython.org">contact us</a>. We'll also have discounted tickets available for active financial supporters of Software Freedom Conservancy.</p>
 
-<p>We look forward to working with Conservancy to advance software freedom and expand the community of Python developers. If this is the first time you've heard of Conservancy, we encourage you to check out <a href="https://sfconservancy.org" title="Software Freedom Conservancy">their website</a> and give them your support.</p>
+<p>We look forward to working with Conservancy to advance software freedom and expand the community of Python developers. If this is the first time you've heard of Conservancy, we encourage you to check out <a href="https://sfconservancy.org">their website</a> and give them your support.</p>
 
 {% endblock %}

--- a/pinaxcon/templates/static_pages/news.html
+++ b/pinaxcon/templates/static_pages/news.html
@@ -13,19 +13,25 @@
 <a name="3"></a>
 <h2>Tickets now on sale for North Bay Python 2017</h2>
 
-<p><span class="date">Tuesday, October 3, 2017</span>&mdash;We are excited to announce that <a href="https://2017.northbaypython.org/tickets">tickets are now on sale</a> for North Bay Python 2017! Tickets are available at a discounted "early bird" rate for the first 100 attendees, or until X, whichever comes first.</p>
+<p><span class="date">Tuesday, October 3, 2017</span>&mdash;We are excited to announce that <a href="https://2017.northbaypython.org/tickets">tickets are now on sale</a> for North Bay Python 2017. With just two months until the conference we have a few key dates coming up:</p>
 
-<p>You can buy a ticket for as low as $25 if you're a student who catches the early bird rate and tickets for corporate employees start at $180. Because we are a nonprofit conference, we also offer individual sponsorships via tickets starting at $450.</p>
+<ul>
+  <li><a href="https://2017.northbaypython.org/tickets">Tickets</a> are available at a discount until Friday, October 20.</li>
+  <li><a href="https://2017.northbaypython.org/attend/hotels">Hotel rooms</a> are available at a discount until Wednesday, November 1.</li>
+  <li><a href="https://2017.northbaypython.org/attend/tshirts">T-shirts</a> can be ordered until Tuesday, November 7.</li>
+</ul>
 
-<p>Can't afford a ticket? Please email <a href="mailto:spam@northbaypython.org">spam@northbaypython.org</a>. We'll enthusiastically waive ticket fees for anyone who needs it.</p>
-
-<p>A limited edition North Bay Python 2017 t-shirt is included with all but the lowest level tickets sold before Wednesday, November 8. You can add t-shirts to any order, as well.</p>
-
-<p>Wondering how you'll get to North Bay Python or where you'll stay? We've gathered all the information you need and are working with local hotels to make sure you have a nice place to stay that fits your budget. Details on our <a href="https://2017.northbaypython.org/about/petaluma">About Petaluma</a> page.</p>
+<p>Can't afford a ticket? Please email <a href="mailto:spam@northbaypython.org">spam@northbaypython.org</a>. We'll enthusiastically waive ticket fees for people who ask.</p>
 
 <p>Need to get approval from your manager to attend North Bay Python 2017? We've outlined the <a href="https://2017.northbaypython.org/attend/business-case">business case</a> to make it clear that North Bay Python is a wise investment.</p>
 
-<p>Our venue can only hold 450 people. <a href="https://2017.northbaypython.org/tickets">Register today</a> so you don't miss out!</p>
+<p>We've prepared a basic <a href="https://2017.northbaypython.org/about/petaluma">travel guide</a> with lodging and travel information. This resource will grow to include local restaurants and other amenities.</p>
+
+<p>Currently we're reviewing 117 proposals from 82 people interested in speaking at North Bay Python 2017. We are grateful to the communities and individuals for: sharing the news, encouraging others, mentoring prospective speakers, crafting proposals, and reviewing those proposals.</p>
+
+<p>Our inaugural event is going to have a fantastic program. We can't wait to announce our keynote speakers and program schedule!</p>
+
+<p><a href="https://2017.northbaypython.org/tickets">Buy tickets</a> and <a href="https://2017.northbaypython.org/attend/hotels">book hotel rooms</a> soon to get the best rates.</p>
 
 <a name="2"></a>
 <h2>Reflecting the Bay in the North Bay Python 2017 speaker lineup</h2>

--- a/pinaxcon/templates/static_pages/program/events.html
+++ b/pinaxcon/templates/static_pages/program/events.html
@@ -1,0 +1,20 @@
+{% extends "page_with_title_and_lede.html" %}
+
+{% load i18n %}
+
+{% block head_title %}Events{% endblock %}
+
+{% block heading %}Events{% endblock %}
+
+{% block body_class %}program{% endblock %}
+
+{% block lede %}
+  Lede
+{% endblock %}
+
+
+{% block content %}
+
+Content
+
+{% endblock %}

--- a/pinaxcon/templates/static_pages/sponsors/donate.html
+++ b/pinaxcon/templates/static_pages/sponsors/donate.html
@@ -6,7 +6,7 @@
 
 {% block heading %}Donate to North Bay Python{% endblock %}
 
-{% block body_class %}about{% endblock %}
+{% block body_class %}sponsors{% endblock %}
 
 {% block lede %}
   Donations to North Bay Python are processed by <a href="https://sfconservancy.org/donate">Software Freedom Conservancy, Inc. a 501(c)(3) organization incorporated in New York</a>, and donations made to it are fully tax-deductible to the extent permitted by law.

--- a/pinaxcon/templates/static_pages/terms_and_conditions.html
+++ b/pinaxcon/templates/static_pages/terms_and_conditions.html
@@ -9,14 +9,10 @@
 
 {% block body_class %}terms-and-conditions{% endblock %}
 
-{% block lede %}Terms and Conditions will be available when tickets are on sale.{% endblock %}
-
 {% block content %}
   {% markdown %}
 
-{% comment %}
 {% include "static_pages/terms_and_conditions.md" %}
-{% endcomment %}
 
   {% endmarkdown %}
 {% endblock %}

--- a/pinaxcon/templates/static_pages/terms_and_conditions.md
+++ b/pinaxcon/templates/static_pages/terms_and_conditions.md
@@ -1,0 +1,117 @@
+*This document was forked from the [Linux Australia Event Terms and Conditions](https://github.com/linuxaustralia/constitution_and_policies/blob/master/terms_and_conditions.md).*
+
+These Terms and Conditions apply to all attendees who have registered for North Bay Python.
+
+Registration
+------------
+
+Registering for the event does not guarantee your ticket until it has been paid for in full. So to secure your ticket, pay the registration invoice as soon as possible.
+
+Security and Credit Cards
+-------------------------
+
+All transactions are performed through a payment gateway facility and use SSL encryption. The facility accepts MasterCard, Visa, and may accept other cards as well. All transactions are performed by the event organizers on behalf of Software Freedom Conservancy.
+
+Cancellation Policy
+-------------------
+
+**Cancellations made prior to November 2, 2017**: Incur a cancellation fee of $25 or 15% of the ticket cost, whichever is greater, which will be deducted from any registration fee paid. The balance will be refunded.
+
+**Cancellations made after November 2, 2017**: No refund.
+
+Substitutions
+-------------
+
+You may substitute another person, however you must contact us with this person's details. If you wish to substitute after November 2, 2017 please note that we will not be able to provide any personalized items.
+
+Privacy Notice
+--------------
+
+In the course of registering for the event and related events, personal information will be collected about attendees such as their name, contact details, etc. This information is required to facilitate registration to the event, for catering requirements, and for organizers or their agents to contact particular attendees as and when required in respect of the event. Attendees who do not disclose this personal information will be unable to complete registration at the event and will therefore not be able to attend.
+
+Personal information will only be disclosed to North Bay Python, Software Freedom Conservancy, and to Government agencies where organizers believe disclosure is appropriate for legal compliance and law enforcement; to facilitate court proceedings; to enforce our terms and conditions; or to protect the rights, property, or safety of the event, our attendees, or others. North Bay Python and Software Freedom Conservancy will not sell your personal information to third parties and will not use your personal information to send promotional material from any of our affiliated partners and/or sponsors.
+
+As part of the registration process attendees will be asked if they would like to subscribe to the event mailing lists and/or the event announcement mailing list. Attendees who subscribe to one or more of these lists will be sent emails from the event organizers and other subscribers to the mailing lists. If at any time, attendees wish to unsubscribe from any of these mailing lists, please follow the 'how to unsubscribe' directions on the bottom of any message you receive from these mailing lists.
+
+From time to time event organizers update their information and website practices. Please regularly review this page for the most recent information about the event privacy practices.
+
+All personal information will be kept private and used only for event registration purposes, statistics for future events, and convenience for future event registration.
+
+Network
+-------
+
+The event may provide attendees with access to a wired and/or wireless network. Access to this network is a privilege and not an entitlement, and must be used appropriately. Inappropriate use includes, but is not limited to: unlawful activities, interfering with the equipment or network access of others and not respecting the reasonable expectations of privacy that attendees have for traffic flowing through the network.
+
+If any attendees use the network inappropriately, then the event organisers will take any enforcement action they consider appropriate. Enforcement action includes but is not limited to:
+
+* suspending access to the network
+* disconnecting the network permanently
+* the alleged offender may be asked to immediately leave the venue and/or will be prohibited from continuing to attend the event (without reimbursement)
+* the incident may be reported to the police
+* any other measure the event organizers see fit
+
+Be aware that for security and operational reasons the event organizers may both monitor and log network traffic.
+
+Discrimination and Anti-Social Behaviour
+----------------------------------------
+
+North Bay Python is proud to support people from all walks of life, especially underrepresented groups like women and people of color, and will not tolerate in any fashion any intimidation, harassment, and/or any abusive, discriminatory or derogatory behaviour by any attendees of the event and/or related events.
+
+Examples of these behaviors and measures the event organizers may take are set out in the [Code of Conduct](/code-of-conduct). By registering for and attending North Bay Python, you agree to this Code of Conduct.
+
+Talk Recordings
+---------------
+
+Event organizers may provide recordings of talks (audio and/or video) given at the event. This service is provided on a best-effort basis only. Any recordings will be released as and when they are ready, which may be some time after the conclusion of the event, and the recordings may be of varying quality.
+
+Photography and Audio Video Recording
+-------------------------------------
+
+This applies to all attendees of North Bay Python and related events, including staff who are designated as official photographers and audio and video recorders.
+
+Do not photograph, video or audio record anyone without their express permission.
+
+Attendees will have a way to visibly signal their preference for photography at the conference. You agree to consider and act according to these preferences:
+
+* Opt-in: Photography always okay
+* Permission required: Ask before photographing
+* Opt-out: Photographs are never okay, don't ask
+
+Attendees who are not visibly signaling their preference should be asked for permission before photographing.  There is no prior opt-in for audio or video recordings. You must always ask before recording. 
+
+The event may have one or more staff taking photographs and/or audio or video recordings during the event. These staff will respect attendees' preferences regarding photography and recordings.
+
+The only exception is for recordings of talks given at the event where attendees who ask questions of the presenter may be included in the talk recording.
+
+If Software Freedom Conservancy or North Bay Python organizers chooses to publish photographs and recordings taken by event staff, we will publish them under a Creative Commons license. Conservancy and North Bay Python further reserve the right to use those photographs and recordings in promotional materials to promote North Bay Python and/or the use of free and open source software.
+
+If there is a violation of this policy, event organizers will request that the photograph be removed from any sites where it was posted and deleted from the devices. In the event that this request is ignored or further violations occur, the participants violating this policy may be sanctioned or expelled from the conference without a refund or banned from future North Bay Python events.
+
+Media
+-----
+
+There are a limited number of Media Passes available to media personnel. Media Passes are free of charge, and entitle media personnel to attend the event with all the entitlements of a Corporate registration. Please note, due to the limited numbers of Media Passes available, all Media Passes will need to be approved by the event organizers.
+
+Any media attending the event are required to identify themselves as "media" to attendees prior to speaking on the record with any attendees of the event. It is the responsibility of the media to introduce themselves to the persons they wish to interview and to arrange any interviews with those persons. The event organizers will not make introductions or arrange interviews on behalf of media.
+
+Students
+--------
+
+Students who register for a student ticket (if available) to attend the event may be required to provide event organizers with proof that they are eligible for registration as a student, such as providing a valid student ID card.
+
+Smoke-free
+----------
+
+All event venues including the social event venues are smoke-free. If attendees wish to smoke during the event and/or related events, they must do so in signed areas. Please consider others and refrain from smoking directly outside the venues' entrances.
+
+Health and Safety
+-----------------
+
+If you are attending the event as a presenter, it is your responsibility to ensure that your talk meets health and safety requirements under United States and California law. If you are unsure about what this means, please contact the event organizers.
+
+Immigration/Entry Requirements
+------------------------------
+
+Anyone who lives outside the United States will need a passport and may require a visa to gain entry into the United States. Please contact your local United States embassy to determine your travel needs. You should take into account the Cancellation Policy above and do this well in advance of the event.
+
+Where a letter of invitation is required, one will be issued by event organizers for presenters whose submissions have been accepted.

--- a/pinaxcon/urls.py
+++ b/pinaxcon/urls.py
@@ -17,29 +17,27 @@ urlpatterns = [
 
     # about
     url(r"^about/north-bay-python$", TemplateView.as_view(template_name="static_pages/about/north_bay_python.html"), name="about/north-bay-python"),
-    # TODO add /about/the-mystic
-    # TODO add /about/petaluma
+    url(r"^about/petaluma$", TemplateView.as_view(template_name="static_pages/about/petaluma.html"), name="about/petaluma"),
     url(r"^about/team$", TemplateView.as_view(template_name="static_pages/about/team.html"), name="about/team"),
     url(r"^about/colophon$", TemplateView.as_view(template_name="static_pages/about/colophon.html"), name="about/colophon"),
     url(r"^about/donate$", TemplateView.as_view(template_name="static_pages/about/donate.html"), name="about/donate"),
     url(r"^donate$", RedirectView.as_view(url="about/donate")),
 
     # program
-    # TODO add /program/sessions
-    # TODO add /program/events
+    url(r"^program/events$", TemplateView.as_view(template_name="static_pages/program/events.html"), name="program/events"),
     url(r"^program/call-for-proposals$", TemplateView.as_view(template_name="static_pages/program/call_for_proposals.html"), name="program/call-for-proposals"),
     url(r"^program/selection-process$", TemplateView.as_view(template_name="static_pages/program/selection_process.html"), name="program/selection-process"),
-
     url(r"^proposals$", RedirectView.as_view(url="program/call-for-proposals")),
     url(r"^cfp$", RedirectView.as_view(url="program/call-for-proposals")),
 
     # attend
-    # TODO add /attend/buy-a-ticket
-    # TODO add /attend/volunteer
-    # TODO add /attend/financial-assistance
-    # TODO add /attend/how-to-pitch-your-manager
-    # TODO add /attend/how-to-get-here
-    # TODO add /attend/where-to-stay
+    url(r"^attend$", TemplateView.as_view(template_name="static_pages/attend/attend.html"), name="attend/attend"),
+    url(r"^tickets$", RedirectView.as_view(url="attend")),
+
+    url(r"^attend/business-case$", TemplateView.as_view(template_name="static_pages/attend/business-case.html"), name="attend/business-case"),
+    url(r"^attend/travel$", TemplateView.as_view(template_name="static_pages/attend/travel.html"), name="attend/travel"),
+    url(r"^attend/hotels$", TemplateView.as_view(template_name="static_pages/attend/hotels.html"), name="attend/hotels"),
+
     url(r"^code-of-conduct$", TemplateView.as_view(template_name="static_pages/code_of_conduct/code_of_conduct.html"), name="code-of-conduct"),
     url(r"^code-of-conduct/harassment-incidents$", TemplateView.as_view(template_name="static_pages/code_of_conduct/harassment_procedure_attendee.html"), name="code-of-conduct/harassment-incidents"),
     url(r"^code-of-conduct/harassment-staff-procedures$", TemplateView.as_view(template_name="static_pages/code_of_conduct/harassment_procedure_staff.html"), name="code-of-conduct/harassment-staff-procedures"),

--- a/pinaxcon/urls.py
+++ b/pinaxcon/urls.py
@@ -20,8 +20,6 @@ urlpatterns = [
     url(r"^about/petaluma$", TemplateView.as_view(template_name="static_pages/about/petaluma.html"), name="about/petaluma"),
     url(r"^about/team$", TemplateView.as_view(template_name="static_pages/about/team.html"), name="about/team"),
     url(r"^about/colophon$", TemplateView.as_view(template_name="static_pages/about/colophon.html"), name="about/colophon"),
-    url(r"^about/donate$", TemplateView.as_view(template_name="static_pages/about/donate.html"), name="about/donate"),
-    url(r"^donate$", RedirectView.as_view(url="about/donate")),
 
     # program
     url(r"^program/events$", TemplateView.as_view(template_name="static_pages/program/events.html"), name="program/events"),
@@ -33,7 +31,6 @@ urlpatterns = [
     # attend
     url(r"^attend$", TemplateView.as_view(template_name="static_pages/attend/attend.html"), name="attend/attend"),
     url(r"^tickets$", RedirectView.as_view(url="attend")),
-
     url(r"^attend/business-case$", TemplateView.as_view(template_name="static_pages/attend/business-case.html"), name="attend/business-case"),
     url(r"^attend/travel$", TemplateView.as_view(template_name="static_pages/attend/travel.html"), name="attend/travel"),
     url(r"^attend/hotels$", TemplateView.as_view(template_name="static_pages/attend/hotels.html"), name="attend/hotels"),
@@ -42,11 +39,15 @@ urlpatterns = [
     url(r"^code-of-conduct/harassment-incidents$", TemplateView.as_view(template_name="static_pages/code_of_conduct/harassment_procedure_attendee.html"), name="code-of-conduct/harassment-incidents"),
     url(r"^code-of-conduct/harassment-staff-procedures$", TemplateView.as_view(template_name="static_pages/code_of_conduct/harassment_procedure_staff.html"), name="code-of-conduct/harassment-staff-procedures"),
     url(r"^terms-and-conditions$", TemplateView.as_view(template_name="static_pages/terms_and_conditions.html"), name="terms-and-conditions"),
+    url(r"^terms$", RedirectView.as_view(url="terms-and-conditions")),
 
     # sponsor
     url(r"^sponsors/prospectus$", RedirectView.as_view(url=_static("assets/northbaypython_prospectus.pdf")), name="sponsors/prospectus"),
     url(r"^northbaypython_prospectus.pdf$", RedirectView.as_view(url=_static("assets/northbaypython_prospectus.pdf")), name="northbaypython_prospectus.pdf"),
     url(r"^sponsors/become-a-sponsor$", TemplateView.as_view(template_name="static_pages/sponsors/become_a_sponsor.html"), name="sponsors/become-a-sponsor"),
+    url(r"^sponsors/donate$", TemplateView.as_view(template_name="static_pages/sponsors/donate.html"), name="sponsors/donate"),
+    url(r"^donate$", RedirectView.as_view(url="sponsors/donate")),
+    url(r"^about/donate$", RedirectView.as_view(url="sponsors/donate")),
 
     # news
     url(r"^news$", TemplateView.as_view(template_name="static_pages/news.html"), name="news"),


### PR DESCRIPTION
update urls, nav, colophon, news, and about north bay python. slight tweak to footer and donate page. add terms and conditions and business case. stub out about petaluma, attend, hotels, travel, events.