### PR TITLE
Correct start of acceptance notification week date

### DIFF
--- a/pinaxcon/templates/static_pages/speak.md
+++ b/pinaxcon/templates/static_pages/speak.md
@@ -16,7 +16,7 @@ Portions of this page were drawn from ideas seen on [DjangoCon EU](https://djang
 
 + **July 1**: Proposal submissions open
 + **August 16**: Proposal submissions close (DEADLINE UPDATED)
-+ **Week of August 23**: Acceptance notifications sent
++ **Week of August 26**: Acceptance notifications sent
 + **Week of September 9**: Speaker confirmations due; program finalized and announced
 + **November 2–3**: Conference happens!
 


### PR DESCRIPTION
```
    August 2019
Su Mo Tu We Th Fr Sa
             1  2  3
 4  5  6  7  8  9 10
11 12 13 14 15 16 17
18 19 20 21 22 23 24
25 26 27 28 29 30 31
```

[Originally reported on Twitter, sorry...](https://twitter.com/lolamby/status/1163538533400764416)